### PR TITLE
Fix qmdiEditor: choosing search history is broken #144

### DIFF
--- a/src/widgets/HistoryLineEdit.cpp
+++ b/src/widgets/HistoryLineEdit.cpp
@@ -52,8 +52,9 @@ void HistoryLineEdit::setHistoryModel(SharedHistoryModel *m) {
         completer = new QCompleter(this);
         completer->setModel(new QStringListModel(historyModel->getHistory(), completer));
         completer->setCaseSensitivity(Qt::CaseInsensitive);
+        // Use QueuedConnection to allow QCompleter to emit 'activated' before the model is updated
         connect(historyModel, &SharedHistoryModel::historyUpdated, this,
-                &HistoryLineEdit::updateCompleter);
+                &HistoryLineEdit::updateCompleter, Qt::QueuedConnection);
     } else {
         if (completer) {
             completer->deleteLater();


### PR DESCRIPTION
Issue: Timing between 'returnPressed' and 'activated' signal being emitted was causing this issue. The 'returnPressed' triggers a model update synchronously. This resets the model before QCompleter finishes processing the 'activated' signal.
Solution: Use QueuedConnection to allow QCompleter to emit 'activated' before the model is updated.