### PR TITLE
Meta: open a new document on first run (#25)

### DIFF
--- a/src/GlobalCommands.hpp
+++ b/src/GlobalCommands.hpp
@@ -36,6 +36,9 @@ inline constexpr const char *VariableInfo = "VariableInfo";
 // Editor requests information about variable below mouse
 inline constexpr const char *KeywordTooltip = "KeywordTooltip";
 
+// Open a new editor, with the attached document
+inline constexpr const char *DisplayText = "DisplayText";
+
 } // namespace GlobalCommands
 
 namespace GlobalArguments {
@@ -56,4 +59,5 @@ inline constexpr const char *Raw = "Raw";
 inline constexpr const char *Tags = "Tags";
 inline constexpr const char *Tooltip = "Tooltip";
 inline constexpr const char *Symbol = "Symbol";
+inline constexpr const char *Content = "Content";
 } // namespace GlobalArguments

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <QStandardPaths>
 #include <QToolButton>
 
+#include "GlobalCommands.hpp"
 #include "pluginmanager.h"
 #include "plugins/CTags/CTagsPlugin.hpp"
 #include "plugins/ProjectManager/ProjectManagerPlg.h"
@@ -23,7 +24,41 @@
 #include "plugins/imageviewer/imageviewer_plg.h"
 #include "plugins/texteditor/texteditor_plg.h"
 
-#define USE_SPLIT
+const QString WelcomContent = R"(
+# Welcome to CodePointer
+
+CodePointer - an IDE for Rust, Go, C++ and more. The application
+will look like a normal text editor, but can
+
+![CodePointer](https://raw.githubusercontent.com/diegoiast/qtedit4/337cd10aab4b123b15dee53c446fd1b7e343dc9a/qtedit4.png)
+
+Some hints for starter:
+
+ * Normal keyboard shortcuts you are used
+   to should work (`control+f`, `control+o`, `control+s` and more).
+ * To select tabs, press `alt+1` etc.
+ * To select/hide/show hide sidebar, press `control+1` (this will open the file
+   manager).
+ * On the top left, you will find the application menu (shortcut is `alt+m`).
+ * You can access the command palette which has all the available commands
+   using `control+shift+p`.
+ * You can press `alt+control+m` to get a conservative menus+toolbars UI.
+ * You can split the editor horizontally by pressing
+
+## Project management
+
+You can also load projects, build and execute them:
+ * If you edit a `CMakeLists.txt` or `meson.build` or `cargo.toml` you will be
+   prompted to open this file as a project. A new sidebar will be opened with
+   the project files.
+ * You can also add an "existing project", by choosing a directory.
+ * You can choose commands to execute for building, or other tasks relevant
+   to this project (configure, build), and you can choose which target
+   to run (`control+b` and `control-r`).
+ * When building, errors are shown at the bottom.
+ * You can execute script files (python, Perl, Bash, PowerShell, etc.), by
+   pressing `control+shift+r`
+)";
 
 int main(int argc, char *argv[]) {
     Q_INIT_RESOURCE(qutepart_syntax_files);
@@ -123,7 +158,11 @@ int main(int argc, char *argv[]) {
     pluginManager.updateGUI();
 
     if (pluginManager.visibleTabs() == 0) {
-        textEditorPlugin->fileNew();
+        CommandArgs args = {
+            {GlobalArguments::FileName, "welcome.md"},
+            {GlobalArguments::Content, WelcomContent},
+        };
+        pluginManager.handleCommandAsync(GlobalCommands::DisplayText, args);
         pluginManager.saveSettings();
     }
 

--- a/src/plugins/texteditor/texteditor_plg.h
+++ b/src/plugins/texteditor/texteditor_plg.h
@@ -57,6 +57,10 @@ class TextEditorPlugin : public IPlugin {
     virtual void showAbout() override;
     virtual void loadConfig(QSettings &settings) override;
     virtual void saveConfig(QSettings &settings) override;
+    virtual int canHandleAsyncCommand(const QString &command,
+                                      const CommandArgs &args) const override;
+    virtual QFuture<CommandArgs> handleCommandAsync(const QString &command,
+                                                    const CommandArgs &args) override;
 
     QStringList myExtensions() override;
     int canOpenFile(const QString &fileName) override;

--- a/src/widgets/qmdieditor.cpp
+++ b/src/widgets/qmdieditor.cpp
@@ -888,7 +888,9 @@ void qmdiEditor::updateClientName() {
 
     if (mdiClientName != newName) {
         mdiClientName = newName;
-        mdiServer->updateClientName(this);
+        if (mdiServer) {
+            mdiServer->updateClientName(this);
+        }
     }
 }
 
@@ -1071,6 +1073,11 @@ void qmdiEditor::hideBannerMessage() {
 }
 
 void qmdiEditor::newDocument() { loadFile(""); }
+
+void qmdiEditor::setPlainText(const QString &plainText) {
+    textEditor->setPlainText(plainText);
+    textEditor->document()->setModified(true);
+}
 
 bool qmdiEditor::doSave() {
     if (fileName.isEmpty()) {

--- a/src/widgets/qmdieditor.h
+++ b/src/widgets/qmdieditor.h
@@ -96,6 +96,7 @@ class qmdiEditor : public QWidget, public qmdiClient {
     void hideBannerMessage();
 
     void newDocument();
+    void setPlainText(const QString &plainText);
     bool doSave();
     bool doSaveAs();
     bool loadFile(const QString &fileName);


### PR DESCRIPTION
1) New API: the text editor plugin can open a new text editor
   with a pre-defined text. This can be used later on by the git
   plugin to display diffs for example.
2) When no editor has been defined, open a new markdown document
   with minimal documentation about this application.

refs #25