### PR TITLE
qmdiEditor: fix crash on load/save when moving fast (162)

### DIFF
--- a/src/widgets/qmdieditor.cpp
+++ b/src/widgets/qmdieditor.cpp
@@ -1175,8 +1175,15 @@ bool qmdiEditor::saveFile(const QString &newFileName, bool makeExecutable) {
         return false;
     }
 
+    QPointer<qmdiEditor> safeThis(this);
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     QApplication::processEvents();
+
+    if (!safeThis) {
+        QApplication::restoreOverrideCursor();
+        return false;
+    }
+
     auto textStream = QTextStream(&file);
     auto cursor = QTextCursor(textEditor->document());
     auto op = Qutepart::AtomicEditOperation(textEditor);
@@ -1363,8 +1370,14 @@ void qmdiEditor::loadContent(bool useBackup) {
     setModificationsLookupEnabled(false);
     hideBannerMessage();
     setReadOnly(false);
+    QPointer<qmdiEditor> safeThis(this);
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     QApplication::processEvents();
+
+    if (!safeThis) {
+        QApplication::restoreOverrideCursor();
+        return;
+    }
 
     QFile file;
     auto loadedFromBackup = false;


### PR DESCRIPTION
If gemini is correct, the cause of the crahses describes in #162 are the `QApplication::processEvents();` used to modify the mouse cursor (otherwise the call has no effect).

A side effect, is that the widget might be destroyed due to that call.

This should fix it.