### PR TITLE
TerminalPlugin: fix fonts issue (184)

### DIFF
--- a/src/plugins/ProjectManager/ProjectBuildConfig.cpp
+++ b/src/plugins/ProjectManager/ProjectBuildConfig.cpp
@@ -233,8 +233,7 @@ bool TaskInfo::operator==(const TaskInfo &other) const {
     /* clang-format on */
 }
 
-QString TaskInfo::getTooltip() const
-{
+QString TaskInfo::getTooltip() const {
     if (!tooltip.isEmpty()) {
         return tooltip;
     }

--- a/src/plugins/ProjectManager/ProjectBuildConfig.h
+++ b/src/plugins/ProjectManager/ProjectBuildConfig.h
@@ -66,8 +66,8 @@ struct ProjectBuildConfig {
     static auto tryGuessFromMeson(const QString &fileName) -> std::shared_ptr<ProjectBuildConfig>;
     static auto buildFromDirectory(const QString &dirName) -> std::shared_ptr<ProjectBuildConfig>;
     static auto buildFromFile(const QString &fileName) -> std::shared_ptr<ProjectBuildConfig>;
-    static auto
-    buildFromJsonFile(const QString &jsonFileName) -> std::shared_ptr<ProjectBuildConfig>;
+    static auto buildFromJsonFile(const QString &jsonFileName)
+        -> std::shared_ptr<ProjectBuildConfig>;
     static auto canLoadFile(const QString &filename) -> bool;
 
     auto updateBinaries() -> void;

--- a/src/plugins/ProjectManager/ProjectManagerPlg.cpp
+++ b/src/plugins/ProjectManager/ProjectManagerPlg.cpp
@@ -86,8 +86,8 @@ static auto regenerateKits(const std::filesystem::path &directoryPath) -> void {
                                   KitDetector::platformUnix);
 }
 
-static auto
-getCommandInterpreter(const QString &externalCommand) -> std::tuple<QString, QStringList> {
+static auto getCommandInterpreter(const QString &externalCommand)
+    -> std::tuple<QString, QStringList> {
     QString interpreter;
     QStringList command;
 

--- a/src/plugins/Terminal/TerminalPlugin.cpp
+++ b/src/plugins/Terminal/TerminalPlugin.cpp
@@ -5,6 +5,7 @@
  * License MIT
  */
 
+#include <KodoTerm/KodoTerm.hpp>
 #include <QCheckBox>
 #include <QDockWidget>
 #include <QFontDatabase>
@@ -12,7 +13,6 @@
 #include <QPushButton>
 #include <QSettings>
 #include <fontwidget.hpp>
-#include <KodoTerm/KodoTerm.hpp>
 #include <qmdidialogevents.hpp>
 
 #include "plugins/Terminal/TerminalPlugin.hpp"

--- a/src/plugins/Terminal/TerminalPlugin.cpp
+++ b/src/plugins/Terminal/TerminalPlugin.cpp
@@ -5,13 +5,13 @@
  * License MIT
  */
 
+#include <QCheckBox>
 #include <QDockWidget>
 #include <QFontDatabase>
 #include <QKeySequence>
 #include <QPushButton>
 #include <QSettings>
 #include <fontwidget.hpp>
-
 #include <KodoTerm/KodoTerm.hpp>
 #include <qmdidialogevents.hpp>
 
@@ -150,15 +150,25 @@ TerminalPlugin::TerminalPlugin() {
                     promptPreviewLabel = label;
                     promptPreviewLabel->setAutoFillBackground(true);
                     promptPreviewLabel->setFrameStyle(QFrame::Panel);
-                    promptPreviewLabel->setFont(getConfig().getTerminalFont());
+                    {
+                        QFont f;
+                        f.fromString(getConfig().getTerminalFont());
+                        f.setStyleStrategy(getConfig().getAntiAlias() ? QFont::PreferAntialias
+                                                                      : QFont::NoAntialias);
+                        promptPreviewLabel->setFont(f);
+                    }
                     updateTerminalPreview();
                 }
 
                 if (item.key == Config::TerminalFontKey) {
                     auto f = qobject_cast<FontWidget *>(widget);
                     connect(f, &FontWidget::fontUpdated, f, [this, f]() {
-                        promptPreviewLabel->setFont(f->font());
+                        QFont font = f->font();
+                        font.setStyleStrategy(getConfig().getAntiAlias() ? QFont::PreferAntialias
+                                                                         : QFont::NoAntialias);
+                        promptPreviewLabel->setFont(font);
                         updateTerminalPreview();
+                        tempConfig.fontString = font.toString();
                     });
                 }
 
@@ -179,6 +189,21 @@ TerminalPlugin::TerminalPlugin() {
                     KodoTerm::populateThemeMenu(themeMenu, tr("iTerm"),
                                                 TerminalTheme::ThemeFormat::ITerm, themeCallback);
                     button->setMenu(themeMenu);
+                }
+
+                if (item.key == Config::AntiAliasKey) {
+                    auto checkbox = qobject_cast<QCheckBox *>(widget);
+                    if (checkbox) {
+                        connect(checkbox, &QCheckBox::toggled, this, [this](bool checked) {
+                            if (promptPreviewLabel) {
+                                auto f = promptPreviewLabel->font();
+                                f.setStyleStrategy(checked ? QFont::PreferAntialias
+                                                           : QFont::NoAntialias);
+                                promptPreviewLabel->setFont(f);
+                                promptPreviewLabel->update();
+                            }
+                        });
+                    }
                 }
                 Q_UNUSED(dialog);
             });
@@ -213,9 +238,12 @@ void TerminalPlugin::configurationHasBeenModified() {
     // Not on this case. We set the button for the config, instead of registering
     // a widget. This means that this data is handled by the dialog itself.
     getConfig().setThemeFile(tempConfig.themeFile);
+    if (!tempConfig.fontString.isEmpty()) {
+        getConfig().setTerminalFont(tempConfig.fontString);
+    }
 
     consoleConfig.setDefaults();
-    consoleConfig.font = getConfig().getTerminalFont();
+    consoleConfig.font.fromString(getConfig().getTerminalFont());
     consoleConfig.tripleClickSelectsLine = getConfig().getTrippleClickClick();
     consoleConfig.copyOnSelect = getConfig().getCopyOnSelect();
     consoleConfig.pasteOnMiddleClick = getConfig().getPasteOnMiddleClick();

--- a/src/plugins/Terminal/TerminalPlugin.hpp
+++ b/src/plugins/Terminal/TerminalPlugin.hpp
@@ -58,5 +58,6 @@ class TerminalPlugin : public IPlugin {
     struct {
         TerminalTheme theme;
         QString themeFile;
+        QString fontString;
     } tempConfig;
 };

--- a/src/plugins/git/CommitForm.cpp
+++ b/src/plugins/git/CommitForm.cpp
@@ -114,8 +114,8 @@ auto GitStatusTableModel::data(const QModelIndex &index, int role) const -> QVar
     }
 }
 
-auto GitStatusTableModel::setData(const QModelIndex &index, const QVariant &value,
-                                  int role) -> bool {
+auto GitStatusTableModel::setData(const QModelIndex &index, const QVariant &value, int role)
+    -> bool {
     if (!index.isValid()) {
         return false;
     }
@@ -142,8 +142,8 @@ auto GitStatusTableModel::flags(const QModelIndex &index) const -> Qt::ItemFlags
     return f;
 }
 
-auto GitStatusTableModel::headerData(int section, Qt::Orientation orientation,
-                                     int role) const -> QVariant {
+auto GitStatusTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+    -> QVariant {
     if (orientation != Qt::Horizontal || role != Qt::DisplayRole) {
         return {};
     }

--- a/src/plugins/texteditor/texteditor_plg.cpp
+++ b/src/plugins/texteditor/texteditor_plg.cpp
@@ -167,8 +167,8 @@ TextEditorPlugin::TextEditorPlugin() {
                                      .setDisplayName(tr("Display font"))
                                      .setKey(Config::FontKey)
                                      .setType(qmdiConfigItem::Font)
-                                     .setDefaultValue(monospacedFont)
-                                     .setValue(monospacedFont)
+                                     .setDefaultValue(monospacedFont.toString())
+                                     .setValue(monospacedFont.toString())
                                      .build());
     config.configItems.push_back(qmdiConfigItem::Builder()
                                      .setKey(Config::ThemeKey)

--- a/src/widgets/qmdieditor.cpp
+++ b/src/widgets/qmdieditor.cpp
@@ -68,8 +68,8 @@
 auto static const cExtensions = QStringList{"c", "cpp", "cxx", "cc", "c++"};
 auto static const headerExtensions = QStringList{"h", "hpp", "hh"};
 
-auto static getCorrespondingFile(PluginManager *manager,
-                                 const QString &fileName) -> QFuture<QString> {
+auto static getCorrespondingFile(PluginManager *manager, const QString &fileName)
+    -> QFuture<QString> {
 
     // First - choose easy solution, file aside the original one
     auto fileInfo = QFileInfo(fileName);


### PR DESCRIPTION
The core of the issue is that we did not properly save the fonts in the config.

Also updated the font display in the config. Antialias is still a little borky, to be dealt with in another issue.